### PR TITLE
fix drawer close in PreviewWindow.tsx

### DIFF
--- a/src/components/PreviewWindow/PreviewWindow.tsx
+++ b/src/components/PreviewWindow/PreviewWindow.tsx
@@ -46,12 +46,12 @@ const PreviewWindow = () => {
     setTabIndex(newTabIndex)
   }
 
-  const handleOpenDrawer = () => setDrawerOpen(() => !drawerOpen)
+  const toggleDrawer = () => setDrawerOpen(prev => !prev)
   const handleCloseDrawer = () => setDrawerOpen(false)
 
   return (
     <PreviewWrapper>
-      <AppBarExample onDrawerButtonClick={handleOpenDrawer} />
+      <AppBarExample onDrawerButtonClick={toggleDrawer} />
       <Tooltip title={`<AppBar color="primary">`} placement="left" arrow>
         <AppBar position="static" id={previewNavTabsId}>
           <Tabs

--- a/src/components/PreviewWindow/PreviewWindow.tsx
+++ b/src/components/PreviewWindow/PreviewWindow.tsx
@@ -35,8 +35,8 @@ function TabPanel(props: TabPanelProps) {
 export const previewNavTabsId = "preview-nav-tabs"
 
 const tabStyle = {
-  minWidth: { sm: 160 }
-};
+  minWidth: { sm: 160 },
+}
 
 const PreviewWindow = () => {
   const [tabIndex, setTabIndex] = React.useState(0)
@@ -46,7 +46,7 @@ const PreviewWindow = () => {
     setTabIndex(newTabIndex)
   }
 
-  const handleOpenDrawer = () => setDrawerOpen(true)
+  const handleOpenDrawer = () => setDrawerOpen(() => !drawerOpen)
   const handleCloseDrawer = () => setDrawerOpen(false)
 
   return (
@@ -62,7 +62,8 @@ const PreviewWindow = () => {
             indicatorColor="secondary"
             scrollButtons
             aria-label="preview-window-tabs"
-            allowScrollButtonsMobile>
+            allowScrollButtonsMobile
+          >
             <Tab label="Instructions" sx={tabStyle} />
             <Tab label="Sign Up" sx={tabStyle} />
             <Tab label="Dashboard" sx={tabStyle} />
@@ -95,7 +96,7 @@ const PreviewWindow = () => {
         </TabPanel>
       </div>
     </PreviewWrapper>
-  );
+  )
 }
 
 export default PreviewWindow


### PR DESCRIPTION
Hey @Zenoo, thanks so much for maintaining and updating the MUI Theme Creator for V5+.

I found a small bug in PreviewWindow.tsx, where `AppBarExample` was unable to close the side drawer after opening. This pull request changes the handler used `const handleOpenDrawer = () => setDrawerOpen(() => !drawerOpen)` to fix the issue. If there is any error, please let me know.

Also, I had a couple other small thoughts that could be helpful for your update if you are interested:
1) updating the GitHub icon link to this repo rather than bareynol's
2) updating the readme to reflect the MUI version of 5+

Thanks again for all the work on this nice tool for MUI users!!

Chris