### PR TITLE
Fix tab color by swapping AppBar with Box

### DIFF
--- a/src/components/MuiComponentSamples/Samples/Tabs.tsx
+++ b/src/components/MuiComponentSamples/Samples/Tabs.tsx
@@ -1,7 +1,6 @@
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import PersonPinIcon from "@mui/icons-material/PersonPin";
 import PhoneIcon from "@mui/icons-material/Phone";
-import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
@@ -53,7 +52,7 @@ export default function TabsExample() {
       flexGrow: 1,
       bgcolor: 'background.paper',
     }}>
-      <AppBar position="static">
+      <Box position="static">
         <Tabs
           value={value}
           onChange={handleChange}
@@ -63,7 +62,7 @@ export default function TabsExample() {
           <Tab label="Favourites" {...a11yProps(1)} />
           <Tab label="Nearby" {...a11yProps(2)} />
         </Tabs>
-      </AppBar>
+      </Box>
       <TabPanel value={value} index={0}>
         Item One
       </TabPanel>
@@ -74,7 +73,7 @@ export default function TabsExample() {
         Item Three
       </TabPanel>
 
-      <AppBar position="static">
+      <Box position="static">
         <Tabs
           value={value}
           onChange={handleChange}
@@ -84,7 +83,7 @@ export default function TabsExample() {
           <Tab icon={<FavoriteIcon />} label="Favourites" {...a11yProps(1)} />
           <Tab icon={<PersonPinIcon />} label="Nearby" {...a11yProps(2)} />
         </Tabs>
-      </AppBar>
+      </Box>
       <TabPanel value={value} index={0}>
         Item One
       </TabPanel>


### PR DESCRIPTION
Tab text is unreadable when inside an appbar in v5

![image](https://user-images.githubusercontent.com/21365658/171950764-f3900dd0-8274-48c2-8dbe-77ead860f04e.png)

Swapping the parent with a box fixes it

![image](https://user-images.githubusercontent.com/21365658/171950838-e34b7949-d86a-416f-8b80-1a001301374f.png)
