### PR TITLE
Fixed iOS Switches, Gradient Buttons and Disable Ripple

### DIFF
--- a/src/components/ThemeTools/SnippetTools/snippets.ts
+++ b/src/components/ThemeTools/SnippetTools/snippets.ts
@@ -45,38 +45,40 @@ const snippets: Array<SnippetModification> = [
     title: "iOS Switches",
     configs: [
       {
-        path: "overrides.MuiSwitch",
+        path: "components.MuiSwitch",
         value: {
-          root: {
-            width: 42,
-            height: 26,
-            padding: 0,
-            margin: 8,
-          },
-          switchBase: {
-            padding: 1,
-            "&$checked, &$colorPrimary$checked, &$colorSecondary$checked": {
-              transform: "translateX(16px)",
-              color: "#fff",
-              "& + $track": {
-                opacity: 1,
-                border: "none",
+          styleOverrides: {
+            root: {
+              width: 46,
+              height: 27,
+              padding: 0,
+              margin: 8,
+            },
+            switchBase: {
+              padding: 1,
+              "&$checked, &$colorPrimary$checked, &$colorSecondary$checked": {
+                transform: "translateX(16px)",
+                color: "#fff",
+                "& + $track": {
+                  opacity: 1,
+                  border: "none",
+                },
               },
             },
-          },
-          thumb: {
-            width: 24,
-            height: 24,
-          },
-          track: {
-            borderRadius: 26 / 2,
-            border: `1px solid ${grey[400]}`,
-            backgroundColor: grey[50],
-            opacity: 1,
-            transition: defaultTheme.transitions.create([
-              "background-color",
-              "border",
-            ]),
+            thumb: {
+              width: 24,
+              height: 24,
+            },
+            track: {
+              borderRadius: 26 / 2,
+              border: `1px solid ${grey[400]}`,
+              backgroundColor: grey[50],
+              opacity: 1,
+              transition: defaultTheme.transitions.create([
+                "background-color",
+                "border",
+              ]),
+            },
           },
         },
       },
@@ -86,16 +88,18 @@ const snippets: Array<SnippetModification> = [
     title: "Gradient Buttons",
     configs: [
       {
-        path: "overrides.MuiButton",
+        path: "components.MuiButton",
         value: {
-          root: {
-            background: "linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)",
-            border: 0,
-            borderRadius: 3,
-            boxShadow: "0 3px 5px 2px rgba(255, 105, 135, .3)",
-            color: "white",
-            height: 48,
-            padding: "0 30px",
+          styleOverrides: {
+            root: {
+              background: "linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)",
+              border: 0,
+              borderRadius: 3,
+              boxShadow: "0 3px 5px 2px rgba(255, 105, 135, .3)",
+              color: "white",
+              height: 48,
+              padding: "0 30px",
+            },
           },
         },
       },
@@ -103,7 +107,12 @@ const snippets: Array<SnippetModification> = [
   },
   {
     title: "Disable Ripple",
-    configs: [{ path: "props.MuiButtonBase.disableRipple", value: true }],
+    configs: [
+      {
+        path: "components.MuiButtonBase.defaultProps.disableRipple",
+        value: true,
+      },
+    ],
   },
   {
     title: "Dense Lists, Tables, Menus",

--- a/src/components/ThemeTools/SnippetTools/snippets.ts
+++ b/src/components/ThemeTools/SnippetTools/snippets.ts
@@ -45,38 +45,38 @@ const snippets: Array<SnippetModification> = [
     title: "iOS Switches",
     configs: [
       {
-        path: "overrides.MuiSwitch",
+        path: "components.MuiSwitch",
         value: {
-          root: {
-            width: 42,
-            height: 26,
-            padding: 0,
-            margin: 8,
-          },
-          switchBase: {
-            padding: 1,
-            "&$checked, &$colorPrimary$checked, &$colorSecondary$checked": {
-              transform: "translateX(16px)",
-              color: "#fff",
-              "& + $track": {
-                opacity: 1,
-                border: "none",
+          styleOverrides: {
+            root: {
+              width: 46,
+              height: 27,
+              padding: 0,
+              margin: 8,
+            },
+            switchBase: {
+              padding: 1,
+              "&$checked, &$colorPrimary$checked, &$colorSecondary$checked": {
+                transform: "translateX(16px)",
+                color: "#fff",
+                "& + $track": {
+                  opacity: 1,
+                  border: "none",
+                },
               },
             },
-          },
-          thumb: {
-            width: 24,
-            height: 24,
-          },
-          track: {
-            borderRadius: 26 / 2,
-            border: `1px solid ${grey[400]}`,
-            backgroundColor: grey[50],
-            opacity: 1,
-            transition: defaultTheme.transitions.create([
-              "background-color",
-              "border",
-            ]),
+            thumb: {
+              width: 24,
+              height: 24,
+            },
+            track: {
+              borderRadius: 13,
+              border: "1px solid #bdbdbd",
+              backgroundColor: "#fafafa",
+              opacity: 1,
+              transition:
+                "background-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
+            },
           },
         },
       },
@@ -86,16 +86,18 @@ const snippets: Array<SnippetModification> = [
     title: "Gradient Buttons",
     configs: [
       {
-        path: "overrides.MuiButton",
+        path: "components.MuiButton",
         value: {
-          root: {
-            background: "linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)",
-            border: 0,
-            borderRadius: 3,
-            boxShadow: "0 3px 5px 2px rgba(255, 105, 135, .3)",
-            color: "white",
-            height: 48,
-            padding: "0 30px",
+          styleOverrides: {
+            root: {
+              background: "linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)",
+              border: 0,
+              borderRadius: 3,
+              boxShadow: "0 3px 5px 2px rgba(255, 105, 135, .3)",
+              color: "white",
+              height: 48,
+              padding: "0 30px",
+            },
           },
         },
       },
@@ -103,7 +105,12 @@ const snippets: Array<SnippetModification> = [
   },
   {
     title: "Disable Ripple",
-    configs: [{ path: "props.MuiButtonBase.disableRipple", value: true }],
+    configs: [
+      {
+        path: "components.MuiButtonBase.defaultProps.disableRipple",
+        value: true,
+      },
+    ],
   },
   {
     title: "Dense Lists, Tables, Menus",


### PR DESCRIPTION
These when applied via Snippets tab, won't get updated in the proview window.
- iOS Switches
- Gradient Buttons
- Disable Ripple

Fixed these by using latest syntax according to MUI docs.